### PR TITLE
Create Bonnet alink_gs.conf

### DIFF
--- a/Bonnet alink_gs.conf
+++ b/Bonnet alink_gs.conf
@@ -1,0 +1,40 @@
+# adaptive-link VRX settings
+
+[outgoing]
+udp_ip = 10.5.0.10
+udp_port = 9999
+
+[json]
+HOST = 127.0.0.1
+PORT = 8103
+
+[weights]
+snr_weight = 0.3
+rssi_weight = 0.7
+
+[ranges]
+SNR_MIN = 12
+SNR_MAX = 28
+RSSI_MIN = -80
+RSSI_MAX = -30
+
+[keyframe]
+allow_idr = True
+idr_max_messages = 20
+
+[dynamic refinement]
+allow_penalty = False
+allow_fec_increase = False
+
+[noise]
+min_noise = 0.01
+max_noise = 0.1
+deduction_exponent = 0.5
+min_noise_for_fec_change = 0.01
+noise_for_max_fec_change = 0.1
+
+[error estimation]
+kalman_estimate = 0.005
+kalman_error_estimate = 0.1
+process_variance = 1e-5
+measurement_variance = 0.01


### PR DESCRIPTION
A modied alink_gs.conf file to use with OpenIPC bonnet RTL8812AU 
Just rename and replace the file with stock alink_gs.conf if using bonnet with groundstation build .